### PR TITLE
Removing an unused & undefined variable which prevents compilation

### DIFF
--- a/src/main/c/spark/randomForestSRC.spark.c
+++ b/src/main/c/spark/randomForestSRC.spark.c
@@ -1016,7 +1016,6 @@ void populateLotObject(jobject obj) {
   RF_lotSize = 0;
   RF_lotLag = 0;
   RF_lotStrikeout = 0;
-  RF_lotInteract = FALSE;
   if (! (*RF_java_env) -> IsSameObject(RF_java_env, obj, NULL)) {
     objClass = (*RF_java_env) -> GetObjectClass(RF_java_env, obj);
     objFieldID = (*RF_java_env) -> GetFieldID(RF_java_env, objClass, "hdim", "I");


### PR DESCRIPTION
I tried to compile via 'ant build-spark' and noticed that it was failing to build because 'RF_lotInteract' is not defined anywhere. It is not used anywhere either. Removing this line will enable it to build again.