### PR TITLE
Guard zero-length yWeight in rfsrcGrow (entry.c:184 UBSAN)

### DIFF
--- a/src/entry.c
+++ b/src/entry.c
@@ -181,7 +181,11 @@ SEXP rfsrcGrow(SEXP traceFlag,
     }
   }
   RF_xWeightStat          = REAL(xWeightStat);  RF_xWeightStat--;
-  RF_yWeight              = REAL(yWeight);  RF_yWeight--;
+  /* yvar.wt is NULL for the unsupervised family (rfsrc.R), so yWeight can be
+     zero length; REAL() then returns the empty-vector sentinel and the
+     decrement forms an out-of-bounds pointer (UB, flagged by UBSAN). It is
+     never read in that case, so the guard changes no behaviour. */
+  RF_yWeight              = REAL(yWeight);  if (XLENGTH(yWeight) > 0) RF_yWeight--;
   RF_xWeight              = REAL(xWeight);  RF_xWeight--;
   RF_timeInterestSize = INTEGER(VECTOR_ELT(timeInterest, 0))[0];
   if (VECTOR_ELT(timeInterest, 1) != R_NilValue) {


### PR DESCRIPTION
rfsrc(Unsupervised() ~ ., data = mtcars, ntree = 1) under -fsanitize=undefined reports:

  entry.c:184:55: runtime error: pointer index expression with base
  0x000000000001 overflowed to 0xfffffffffffffff9

rfsrc.R sets yvar.wt <- NULL for the unsupervised family, so the .Call passes as.double(NULL) == double(0). REAL() on a zero-length vector returns R's empty-vector sentinel rather than an allocation, and decrementing it forms an out-of-bounds pointer. The pointer is never dereferenced when the vector is empty, so guarding the decrement changes no behaviour -- it only avoids constructing the invalid pointer.

Only yWeight is affected. xWeightStat (split.wt) and xWeight (xvar.wt) both come from get.weight(), which returns rep(1, n.xvar) when NULL and errors on a length mismatch, so neither can be zero length. Their decrements are left alone rather than guarded speculatively.

XLENGTH is used because as.double(NULL) is a zero-length REALSXP, not R_NilValue, so a NULL check would not catch it.

This surfaces on CRAN's gcc-UBSAN additional check for downstream packages that grow an unsupervised forest, including pure-R packages that only call rfsrc().